### PR TITLE
Allow 'formatting' of values

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,12 @@ Group a sorted stream by key.
 npm install sorted-group-stream
 ```
 
-### `group([toKey])`
+### `group([toKey], [format])`
 A transform stream that groups objects by key.
 
 Keys are mapped by `value.key` or `value` itself. Pass `toKey` function for custom key mapping.
+
+If you want to format the values, you can pass a `format` function as the second argument.
 
 ```js
 var group = require('sorted-group-stream')

--- a/index.js
+++ b/index.js
@@ -4,9 +4,16 @@ function defaultKey (val) {
   return val.key || val
 }
 
-module.exports = function group (toKey) {
+function identity (val) {
+  return val
+}
+
+module.exports = function group (toKey, format) {
   if (typeof toKey !== 'function') {
     toKey = defaultKey
+  }
+  if (typeof format !== 'function') {
+    format = identity
   }
   var curr, value
   return new Transform({
@@ -18,7 +25,7 @@ module.exports = function group (toKey) {
         value = []
         curr = next
       }
-      value.push(data)
+      value.push(format(data))
       cb()
     },
     flush: function (cb) {

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var through = require('through2')
+var Transform = require('stream').Transform
 
 function defaultKey (val) {
   return val.key || val
@@ -9,17 +9,21 @@ module.exports = function group (toKey) {
     toKey = defaultKey
   }
   var curr, value
-  return through.obj(function (data, enc, cb) {
-    var next = toKey(data)
-    if (curr !== next) {
+  return new Transform({
+    objectMode: true,
+    transform: function (data, enc, cb) {
+      var next = toKey(data)
+      if (curr !== next) {
+        if (value) this.push({ key: curr, value: value })
+        value = []
+        curr = next
+      }
+      value.push(data)
+      cb()
+    },
+    flush: function (cb) {
       if (value) this.push({ key: curr, value: value })
-      value = []
-      curr = next
+      cb()
     }
-    value.push(data)
-    cb()
-  }, function (cb) {
-    if (value) this.push({ key: curr, value: value })
-    cb()
   })
 }

--- a/package.json
+++ b/package.json
@@ -3,9 +3,7 @@
   "version": "3.0.0",
   "description": "Group a sorted stream by key",
   "author": "Adrian C Shum <adrian@cshum.com> (https://github.com/cshum)",
-  "dependencies": {
-    "through2": "^2.0.1"
-  },
+  "dependencies": {},
   "devDependencies": {
     "callback-stream": "^1.1.0",
     "from2": "^2.1.0",

--- a/test.js
+++ b/test.js
@@ -44,6 +44,30 @@ test('group by custom key', function (t) {
   }))
 })
 
+test('group with custom format and custom key', function (t) {
+  from.obj([
+    {id: 1, v: 'a'},
+    {id: 1, v: 'b'},
+    {id: 2, v: 'a'},
+    {id: 3, v: 'b'},
+    {id: 3, v: 'd'}
+  ])
+  .pipe(group(function (data) {
+    return data.id
+  }, function (data) {
+    return data.v
+  }))
+  .pipe(callback.obj(function (err, data) {
+    t.notOk(err)
+    t.deepEqual(data, [
+      {key: 1, value: [ 'a', 'b' ]},
+      {key: 2, value: [ 'a' ]},
+      {key: 3, value: [ 'b', 'd' ]}
+    ])
+    t.end()
+  }))
+})
+
 test('merge sort and group by custom key', function (t) {
   function toKey (data) {
     return data.id


### PR DESCRIPTION
In my use case I want to group values, but for the result I don't want the full objects, but only specific keys. It therefore makes sense to have a `format` function as arguments, that allows to select the part of the stream that you want to see in values.

I also replace `through2` with the new `stream.Transform` syntax. But let me know if you don't like it.

I also added some tests and docs